### PR TITLE
Fix: rand.Intn(n) The parameter value cannot be 0 #19

### DIFF
--- a/internal/chatgpt/request.go
+++ b/internal/chatgpt/request.go
@@ -63,7 +63,7 @@ func SendRequest(message typings.ChatGPTRequest, access_token string) (*http.Res
 		client.SetProxy(http_proxy)
 	}
 	// Take random proxy from proxies.txt
-	if len(proxies) > 0 {
+	if len(proxies) > 1 {
 		client.SetProxy(proxies[random_int(0, len(proxies)-1)])
 	}
 


### PR DESCRIPTION
Fix a small bug #19 