### PR TITLE
Fixed response_part being empty when Continuing conversation

### DIFF
--- a/internal/chatgpt/request.go
+++ b/internal/chatgpt/request.go
@@ -186,7 +186,7 @@ func Handler(c *gin.Context, response *http.Response, token string, translated_r
 			if original_response.Message.Author.Role != "assistant" || original_response.Message.Content.Parts == nil {
 				continue
 			}
-			if original_response.Message.Metadata.MessageType != "next" {
+			if original_response.Message.Metadata.MessageType != "next" && original_response.Message.Metadata.MessageType != "continue" {
 				continue
 			}
 			response_string := chatgpt_response_converter.ConvertToString(&original_response, &previous_text)


### PR DESCRIPTION
When `Continuing conversation`, the value of `original_response.Message.Metadata.MessageType` is `continue`